### PR TITLE
DO_NOT_SHOW severity

### DIFF
--- a/src/ReSharperToCodeClimate/Program.cs
+++ b/src/ReSharperToCodeClimate/Program.cs
@@ -26,11 +26,14 @@ namespace ReSharperToCodeClimate
 
             foreach (XElement issue in reSharperReport.Descendants("Issue"))
             {
-                codeClimateReport.Add(
-                    new CodeClimateIssue()
+                var severity = severityByIssueType[issue.Attribute("TypeId").Value];
+                if (string.IsNullOrEmpty(severity))
+                    continue;
+
+                codeClimateReport.Add(new CodeClimateIssue
                     {
                         Description = issue.Attribute("Message").Value,
-                        Severity = severityByIssueType[issue.Attribute("TypeId").Value],
+                        Severity = severity,
                         Fingerprint = CalculateFingerprint(issue),
                         Location = new IssueLocation()
                         {
@@ -55,18 +58,19 @@ namespace ReSharperToCodeClimate
                 {"ERROR", "critical"},
                 {"WARNING", "major"},
                 {"SUGGESTION", "minor"},
-                {"HINT", "info"}
+                {"HINT", "info"},
+                {"DO_NOT_SHOW", string.Empty}
             };
 
-            Dictionary<string, string> serverityByIssueType = new Dictionary<string, string>();
+            Dictionary<string, string> severityByIssueType = new Dictionary<string, string>();
 
             foreach (var issueType in issueTypes)
             {
                 string severity = codeClimateSeverityByReSharperSeverity[issueType.Attribute("Severity").Value];
-                serverityByIssueType.Add(issueType.Attribute("Id").Value, severity);
+                severityByIssueType.Add(issueType.Attribute("Id").Value, severity);
             }
 
-            return serverityByIssueType;
+            return severityByIssueType;
         }
 
         private static ConcurrentDictionary<string, int> FingerprintCounters = new();

--- a/src/ReSharperToCodeClimate/ReSharperToCodeClimate.csproj
+++ b/src/ReSharperToCodeClimate/ReSharperToCodeClimate.csproj
@@ -4,14 +4,14 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
-    <Version>1.0.6</Version>
+    <Version>1.0.7</Version>
     <RootNamespace>ReSharperToCodeClimate</RootNamespace>
     <AssemblyName>resharper-to-codeclimate</AssemblyName>
     <PackAsTool>true</PackAsTool>
     <PackageId>resharper-to-codeclimate</PackageId>
     <Authors>Thomas Weston</Authors>
     <PackageDescription>Converts a ReSharper inspectcode xml report file to a Code Climate json report file.</PackageDescription>
-    <PackageReleaseNotes>Improved fingerprint generation</PackageReleaseNotes>
+    <PackageReleaseNotes>Added DO_NOT_SHOW resharper severity</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/moly/resharper-to-codeclimate</PackageProjectUrl>
     <RepositoryUrl>https://github.com/moly/resharper-to-codeclimate</RepositoryUrl>
     <PackageTags>resharper codeclimate gitlab</PackageTags>


### PR DESCRIPTION
If resharper codestyle setting set to "Do not show", the same severity goes to output xml, results following exception:

`
Unhandled exception. System.Collections.Generic.KeyNotFoundException: The given key 'DO_NOT_SHOW' was not present in the dictionary.
`

This request ignores DO_NOT_SHOW severity and fix typo.

--
update nuget as merged please