### PR TITLE
Add support for check_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ note, currently only converts to the subset of the code climate spec [required f
 ## usage
 
 ```powershell
-dotnet tool install -g dotnet-resharper-to-codeclimate
+dotnet tool install -g resharper-to-codeclimate
 dotnet resharper-to-codeclimate results.xml results.json
 ```
 

--- a/src/ReSharperToCodeClimate/Program.cs
+++ b/src/ReSharperToCodeClimate/Program.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Xml.Linq;
+using JorgeSerrano.Json;
 
 namespace ReSharperToCodeClimate
 {
@@ -33,6 +34,7 @@ namespace ReSharperToCodeClimate
                 codeClimateReport.Add(new CodeClimateIssue
                     {
                         Description = issue.Attribute("Message").Value,
+                        CheckName = issue.Attribute("Id").Value,
                         Severity = severity,
                         Fingerprint = CalculateFingerprint(issue),
                         Location = new IssueLocation()
@@ -47,7 +49,7 @@ namespace ReSharperToCodeClimate
                 );
             }
 
-            JsonSerializerOptions options = new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+            JsonSerializerOptions options = new JsonSerializerOptions() { PropertyNamingPolicy = new JsonSnakeCaseNamingPolicy() };
             File.WriteAllText(args[1], JsonSerializer.Serialize(codeClimateReport, options));
         }
 
@@ -106,6 +108,8 @@ namespace ReSharperToCodeClimate
 
     class CodeClimateIssue
     {
+        public String CheckName { get; set; }
+        
         public string Description { get; set; }
 
         public string Fingerprint { get; set; }

--- a/src/ReSharperToCodeClimate/ReSharperToCodeClimate.csproj
+++ b/src/ReSharperToCodeClimate/ReSharperToCodeClimate.csproj
@@ -20,4 +20,8 @@
     <PackageOutputPath>./nupkg</PackageOutputPath>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="JorgeSerrano.Json.JsonSnakeCaseNamingPolicy" Version="0.9.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
The GitLab spec now supports a property called "check_name" that can be used for the IssueType Id.